### PR TITLE
Fix supabase flag boolean and cleanup

### DIFF
--- a/components/PromptPreview.tsx
+++ b/components/PromptPreview.tsx
@@ -2,7 +2,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { renderTemplate } from '@/lib/renderTemplate';
 
 interface PromptPreviewProps {
     prompt: string;

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -72,9 +72,10 @@ const mockSupabaseClient = {
 };
 
 // Determine whether to use real or mock client
-const useRealSupabase =
+const useRealSupabase = Boolean(
   process.env.NEXT_PUBLIC_SUPABASE_URL &&
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
 
 // Export either the real client or the mock client
 export const supabase = useRealSupabase


### PR DESCRIPTION
## Summary
- fix boolean check for real Supabase client
- remove unused import in PromptPreview

## Testing
- `pnpm lint` *(fails: next not found)*