### PR TITLE
Add basic node:test with placeholder tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 ```bash
 pnpm i          # or npm install
 pnpm dev        # next dev
+pnpm test       # run unit tests
 ```
 
 Set the following env vars (e.g. in `.env.local`):

--- a/lib/usePlaceholders.ts
+++ b/lib/usePlaceholders.ts
@@ -12,23 +12,7 @@ export function usePlaceholders(template: string): string[] {
     const [placeholders, setPlaceholders] = useState<string[]>([])
 
     useEffect(() => {
-        if (!template) {
-            setPlaceholders([])
-            return
-        }
-
-        // Regular expression to match Handlebars placeholders
-        // This will match {{variable}} but ignore {{#if}}, {{else}}, etc.
-        const regex = /{{([^#\/][^}]+?)}}/g
-        const matches = template.match(regex) || []
-
-        // Extract variable names and clean them
-        const extractedPlaceholders = matches
-            .map(match => match.replace(/{{|}}/g, '').trim())
-            .filter(placeholder => !placeholder.includes(' ')) // Filter out helpers with arguments
-            .filter((value, index, self) => self.indexOf(value) === index) // Remove duplicates
-
-        setPlaceholders(extractedPlaceholders)
+        setPlaceholders(extractPlaceholders(template))
     }, [template])
 
     return placeholders
@@ -42,9 +26,11 @@ export function usePlaceholders(template: string): string[] {
 export function extractPlaceholders(template: string): string[] {
     if (!template) return []
 
-    const placeholderRegex = /\{\{([^}]+)\}\}/g
+    const placeholderRegex = /\{\{([^#\/][^}]*)\}\}/g
     const matches = [...template.matchAll(placeholderRegex)]
-    const extractedFields = matches.map((match) => match[1].trim())
+    const extractedFields = matches
+        .map((match) => match[1].trim())
+        .filter((name) => name !== 'else' && !name.includes(' '))
 
     // Remove duplicates
     return [...new Set(extractedFields)]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",

--- a/tests/usePlaceholders.test.ts
+++ b/tests/usePlaceholders.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { create } from 'react-test-renderer'
+import { usePlaceholders, extractPlaceholders } from '../lib/usePlaceholders'
+
+test('extractPlaceholders ignores helpers like {{else}}', () => {
+  const template = '{{greeting}} {{#if name}}{{name}}{{else}}no name{{/if}}'
+  const result = extractPlaceholders(template)
+  assert.deepEqual(result, ['greeting', 'name'])
+})
+
+test('usePlaceholders returns placeholders and ignores helpers', async () => {
+  let value: string[] = []
+  const Wrapper = ({ template }: { template: string }) => {
+    value = usePlaceholders(template)
+    return null
+  }
+
+  await act(async () => {
+    create(<Wrapper template="{{#if foo}}{{foo}}{{else}}bar{{/if}} {{bar}}" />)
+  })
+
+  // wait for useEffect
+  await Promise.resolve()
+  assert.deepEqual(value, ['foo', 'bar'])
+})


### PR DESCRIPTION
## Summary
- set up `node --test` script
- ignore `{{else}}` in placeholder utilities
- provide unit tests for `usePlaceholders` and `extractPlaceholders`
- document test command in README

## Testing
- `npm test` *(fails: no tests run, dependencies missing)*