### PR TITLE
Implement AI-based template analysis

### DIFF
--- a/app/api/templates/analyze/route.ts
+++ b/app/api/templates/analyze/route.ts
@@ -2,6 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { analyzeTemplateWithRegex } from '../../../../lib/template-service';
 import { TemplateVariable } from '../../../../types/templates';
+import OpenAI from 'openai';
+
+// Log OpenAI initialization status (without exposing the full key)
+const openaiApiKey = process.env.OPENAI_API_KEY;
+const isMockKey = !openaiApiKey || openaiApiKey === 'sk-mock-key';
+console.log(`OpenAI API Key status: ${openaiApiKey ? 'Provided' : 'Missing'}`);
+console.log(`Using mock data for template analysis: ${isMockKey}`);
+
+const openai = new OpenAI({
+    apiKey: openaiApiKey || 'sk-mock-key'
+});
 
 /**
  * POST /api/templates/analyze
@@ -19,9 +30,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        // In a production environment, you would use an AI service here
-        // This is a simple regex-based implementation
-        const result = analyzeTemplateWithRegex(text);
+        const result = await analyzeTemplateWithAI(text);
 
         return NextResponse.json(result);
     } catch (error) {
@@ -33,32 +42,46 @@ export async function POST(request: NextRequest) {
     }
 }
 
-/**
- * Future implementation with AI
- * Uncomment and modify this function when you have an AI provider set up
- */
-/*
 async function analyzeTemplateWithAI(text: string) {
-  // Replace with your AI provider API call
-  // Example with OpenAI:
-  // const response = await openai.chat.completions.create({
-  //   model: "gpt-4",
-  //   messages: [
-  //     {
-  //       role: "system",
-  //       content: "Analyze the following template text and identify variables in the format {{variable_name}}. For each variable, suggest a description and type (text, number, or select)."
-  //     },
-  //     {
-  //       role: "user",
-  //       content: text
-  //     }
-  //   ]
-  // });
-  
-  // Parse AI response and extract variables
-  // This would depend on your AI service's response format
-  
-  // For now, we'll just use regex
-  return analyzeTemplateWithRegex(text);
+    // If we're definitely using a mock key, fall back to regex
+    if (isMockKey) {
+        console.log('Using regex analyzer due to missing/invalid API key');
+        return analyzeTemplateWithRegex(text);
+    }
+
+    try {
+        const systemPrompt =
+            'Analyze the following template text and identify variables in the format {{variable_name}}. ' +
+            'Return JSON with "processedText" and "detectedVariables" (each variable should have name, description, and type).';
+
+        const response = await openai.chat.completions.create({
+            model: 'gpt-4o',
+            messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: text }
+            ],
+            response_format: { type: 'json_object' }
+        });
+
+        const content = response.choices[0]?.message.content || '{}';
+        const parsed = JSON.parse(content);
+
+        const processedText = parsed.processedText || text;
+        const detectedVariables: TemplateVariable[] = Array.isArray(parsed.detectedVariables)
+            ? parsed.detectedVariables.map((v: any) => ({
+                  id: uuidv4(),
+                  name: v.name,
+                  description: v.description || `Value for ${v.name}`,
+                  type:
+                      v.type === 'number' || v.type === 'select'
+                          ? v.type
+                          : 'text'
+              }))
+            : [];
+
+        return { processedText, detectedVariables };
+    } catch (error) {
+        console.error('AI analysis failed, falling back to regex:', error);
+        return analyzeTemplateWithRegex(text);
+    }
 }
-*/ 


### PR DESCRIPTION
## Summary
- integrate OpenAI client in template analysis endpoint
- implement `analyzeTemplateWithAI` for GPT-4o
- fall back to regex analysis when API key is missing or errors occur

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm exec next lint` *(fails: command not found)*